### PR TITLE
Fix reading config file

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,8 @@ void setup() {
   }
 
   preferences_init();
+  TM_changeID(preferences_get_id());
+  LORA_changeFrequency(preferences_get_frequency());
 
   if(OLED_init(preferences_get_OLEDdriver())){
     Serial.println(F("OLED init done!"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,17 +28,17 @@ void setup() {
   Serial.println(F("App start!"));
   SPIFFS.begin();
 
+  if(FS_init()){
+    Serial.println(F("FS init done!"));
+  }
+
+  preferences_init();
+
   if(OLED_init(preferences_get_OLEDdriver())){
     Serial.println(F("OLED init done!"));
     OLED_clear();
     OLED_drawString(0, 5, "OLED OK");
   }
-  if(FS_init()){
-    Serial.println(F("FS init done!"));
-    OLED_drawString(0, 13, "FS OK");
-  }  
-
-  preferences_init();
 
   if(GNSS_init()){
     Serial.println(F("GNSS init done!"));
@@ -49,9 +49,6 @@ void setup() {
     OLED_drawString(0, 21, "LORA OK");
   } 
 
-  LORA_changeFrequency(preferences_get_frequency());
-  TM_changeID(preferences_get_id());
-  
   //SQL init
   SQL_init();
 

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -1,6 +1,8 @@
 
 #include "FS.h"
 #include "SPIFFS.h"
+#include "lora.h"
+#include "TeleMetry.h"
 #include <string>
 #include <ArduinoJson.h>
 #include "preferences.h"
@@ -34,8 +36,7 @@ int preferences_init(){
         config["configuration"]["oled_driver"] = SH1106;
 
         serializeJson(config, file);
-        file.close(); 
-
+        file.close();
     }
     
     file = SPIFFS.open(path, FILE_READ);
@@ -50,6 +51,8 @@ int preferences_init(){
     config_data_d.id = config["configuration"]["id"];
     config_data_d.oled_driver = config["configuration"]["oled_driver"];
 
+    TM_changeID(config_data_d.id);
+    LORA_changeFrequency(config_data_d.frequency);
 
     return 0;
 }

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -1,8 +1,6 @@
 
 #include "FS.h"
 #include "SPIFFS.h"
-#include "lora.h"
-#include "TeleMetry.h"
 #include <string>
 #include <ArduinoJson.h>
 #include "preferences.h"
@@ -50,9 +48,6 @@ int preferences_init(){
     config_data_d.frequency = config["configuration"]["frequency"];
     config_data_d.id = config["configuration"]["id"];
     config_data_d.oled_driver = config["configuration"]["oled_driver"];
-
-    TM_changeID(config_data_d.id);
-    LORA_changeFrequency(config_data_d.frequency);
 
     return 0;
 }


### PR DESCRIPTION
1. Removed `LORA_changeFrequency` and `TM_changeID` from setup function as `preferences_init()` sets up default values. 
2. moved to top `FS_init()` as it is needed to read config file.
3. moved up `preferences_init()` to load config file before setting up external devices. 